### PR TITLE
fix: 修复UTF8下中文字符长度判断错误导致的中文短文本滚动

### DIFF
--- a/OLED_UI_Core/HAL/OLED_UI_Core/OLED_UI/OLED_UI.c
+++ b/OLED_UI_Core/HAL/OLED_UI_Core/OLED_UI/OLED_UI.c
@@ -512,7 +512,10 @@ int16_t CalcStringWidth(int16_t ChineseFont, int16_t ASCIIFont, const char *form
     while (*ptr != '\0') {
         if ((unsigned char)*ptr & 0x80) { // 处理中文字符
             StringLength += ChineseFont;
-            ptr += 2;
+            if ((*ptr & 0xF0) == 0xF0) ptr += 4;      // 4字节字符
+        	else if ((*ptr & 0xE0) == 0xE0) ptr += 3;  // 3字节中文 
+        	else if ((*ptr & 0xC0) == 0xC0) ptr += 2;  // 2字节字符
+        	else ptr += 2;  // fallback 
         } else {
             StringLength += ASCIIFont;
             ptr++;


### PR DESCRIPTION
## 问题描述
在将所有文件编码转换为UTF-8，并且修改 OLED_CHN_CHAR_WIDTH 为 3 后，出现了中文短文本也像长文本一样在循环滚动播放的情况（例如示例程序中More中的 "字体高度12demo"，"字体高度16demo"等）
## 修复方案
修复 OLED_UI/OLED_UI_Core/HAL/OLED_UI_Core/OLED_UI/OLED_UI.c 中 CalcStringWidth 函数中文长度判断逻辑
## 测试验证
硬件：STM32F103C8T6
编译环境：Keil5/CLion+Cmake
（第一次Pull Request，不知道这样写对不对）
